### PR TITLE
2 helm install commands and fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ helm repo update
 
 ### ✅  Helm 3 Install
 ```
-helm install k8ssandra k8ssandra/k8ssandra
-helm install k8ssandra-cluster k8ssandra/k8ssandra-cluster
+helm install k8ssandra-tools k8ssandra/k8ssandra
+helm install k8ssandra-cluster-a k8ssandra/k8ssandra-cluster
 ```
 
 ### ✅  Monitor things as they come up
@@ -74,7 +74,7 @@ helm get manifest k8ssandra | grep size
 
 Notice the value of `size: 2` in the TODO.yaml .
 
-Open the values.yaml and find the nodeCount paramater.
+Open the values.yaml and find the nodeCount parameter.
 
 Change the value from 2 to 3 `nodeCount: 3`.
 


### PR DESCRIPTION
Helm commands: recommend changing to be consistent with doc Getting Started, and they work in sequence with no namespace conflict.  Also, typo fix: change paramater to parameter.